### PR TITLE
Add XiuRouter unified gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Covers the full-stack AI infrastructure for the enterprise — AI chips, compute
 **VI. Unified Gateway**
 
 * **[LiteLLM](https://github.com/BerriAI/litellm):** A unified LLM gateway with an OpenAI-compatible API — model routing, rate limits, budgets, and logging for enterprise private deployments.
+* **[XiuRouter](https://router.xiu.ai/):** A hosted multi-model API with native OpenAI Responses and Chat Completions, Anthropic Messages, and Gemini GenerateContent routes, scoped API keys, usage-based pricing, and request-level usage and cost records.
 
 **VII. Security & Guardrails**
 


### PR DESCRIPTION
## Summary

Adds XiuRouter to the Unified Gateway section as a hosted multi-model API.

## Validation

- One README entry only
- Official HTTPS product URL returns HTTP 200
- Description is limited to public product facts: native OpenAI Responses and Chat Completions, Anthropic Messages, Gemini GenerateContent, scoped API keys, usage-based pricing, and request-level usage/cost records
- `git diff --check` passes
- No existing entries or sections are changed

## Disclosure

I am affiliated with XiuRouter and XiuLab Inc. This contribution was prepared with AI assistance and reviewed against the current public product and documentation pages.