### PR TITLE
Add SandBase Harness to AI agent engineering projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ The following open-source projects represent prominent examples of agentic AI en
 | **[OpenClaw](https://github.com/openclaw/openclaw)** | Personal AI assistant, local-first, any OS/platform | Local-first Gateway, multi-channel messaging, voice support, session & tool management |
 | **[Pi](https://github.com/earendil-works/pi)** | Open-source AI agent toolkit: unified multi-provider LLM API, agent runtime, and an interactive coding agent CLI | Self-extensible coding agent, multi-provider API, terminal UI library, npm supply-chain hardening |
 | **[DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)** | DeepSeek AI's open-source agent harness with a plugin-driven architecture ("everything is a plugin") | Plugin composability via Cordis, Web UI, monorepo, developer preview |
+| **[SandBase Harness](https://github.com/sandbaseai/sandbase-harness)** | Local-first, self-hosted runtime for building and operating AI agents with persistent sessions, event streams, MCP tools, and sandboxed execution | Docker/Kubernetes deployment, approvals, audit and replay, extensible skills and credentials |
 
 > These projects showcase diverse agent architectures — from developer-focused coding agents (Claude Code/OpenAI Codex/claurst) to general-purpose personal assistants (OpenClaw) and self-learning agents (Hermes-Agent). Studying their design decisions is valuable for building your own agent systems.
   
@@ -427,4 +428,3 @@ To prevent "cheating" through shared state, every evaluation trial runs in a fre
 * **Cleanup & Anti-Leakage**: Aggressive state teardown (no shared history) and guard against goal leakage that could let the agent take shortcuts via shared state.
 
 [⬆️ Back to Top : Table of Contents](#top)
-


### PR DESCRIPTION
## Summary
- add SandBase Harness to the open-source agent engineering project table
- describe its local-first runtime, persistent sessions, MCP, sandboxing, approvals, audit, and replay capabilities

## Verification
- Official repository: https://github.com/sandbaseai/sandbase-harness
- Current release: v0.3.8
- Entry uses the project's public README and release-backed capabilities.
