### PR TITLE
Add YYLO to agentic AI engineering projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ The following open-source projects represent prominent examples of agentic AI en
 | **[OpenClaw](https://github.com/openclaw/openclaw)** | Personal AI assistant, local-first, any OS/platform | Local-first Gateway, multi-channel messaging, voice support, session & tool management |
 | **[Pi](https://github.com/earendil-works/pi)** | Open-source AI agent toolkit: unified multi-provider LLM API, agent runtime, and an interactive coding agent CLI | Self-extensible coding agent, multi-provider API, terminal UI library, npm supply-chain hardening |
 | **[DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)** | DeepSeek AI's open-source agent harness with a plugin-driven architecture ("everything is a plugin") | Plugin composability via Cordis, Web UI, monorepo, developer preview |
+| **[YYLO](https://github.com/yylo-dev/yylo)** | Open-source command-line orchestrator for coding agents, repeatable workflows, and receipt-backed repository changes | Typed task/validation/merge/release-readiness boundaries, dedicated branch/worktree per task, merge queue with risk-based review, Pi and Codex subagents |
 
 > These projects showcase diverse agent architectures — from developer-focused coding agents (Claude Code/OpenAI Codex/claurst) to general-purpose personal assistants (OpenClaw) and self-learning agents (Hermes-Agent). Studying their design decisions is valuable for building your own agent systems.
   


### PR DESCRIPTION
## Summary

Adds **[YYLO](https://github.com/yylo-dev/yylo)** to the *Key Open-Source Projects & References* table under **Building AI Agents**, beside Claude Code, OpenAI Codex, Pi, and SandBase Harness.

YYLO is an open-source command-line orchestrator for coding agents, repeatable workflows, and receipt-backed repository changes — it provides typed task, validation, merge, and release-readiness boundaries: each task runs in a dedicated branch/worktree, and a merge queue owns risk-based review across Pi and Codex subagents. One row, README-only, matching the house table format (`| Project | Description | Key Strengths |`).

## Verification

- Row inserted at the bottom of the table, following the shape of merged #4 (SandBase Harness) and #2 (Agent QA): single-line README.md addition, no other files touched.
- Every description phrase is taken verbatim from the YYLO README (project description and the safety-invariants section).
- Repo health at submission: MIT license, 57 stars, ~8 months old, daily pushes, published on npm as `@yylo/cli`.

## Disclosure

I am on the team that builds YYLO; this submission was prepared with an AI coding agent and is a self-submission of our own open-source project, in the same spirit as the existing external project rows.
